### PR TITLE
fix feedreader login error

### DIFF
--- a/data/tt-rss-feedreader-plugin/api_feedreader/init.php
+++ b/data/tt-rss-feedreader-plugin/api_feedreader/init.php
@@ -35,7 +35,7 @@ class Api_feedreader extends Plugin {
 	function removeLabel()
 	{
 		$label_id = (int)$_REQUEST["label_id"];
-		if($label_id != "")
+		if($label_id != 0)
 		{
 			Labels::remove(Labels::feed_to_label_id($label_id), $_SESSION["uid"]);
 			return array(API::STATUS_OK);


### PR DESCRIPTION
fix feedreader login error "install the api_feedreader plugin on your tt-rss instance". related to issue #11 
